### PR TITLE
feat: mejorar navegación responsive

### DIFF
--- a/index.css
+++ b/index.css
@@ -6,23 +6,15 @@ html, body {
     overflow-x: hidden; /* Elimina cualquier desbordamiento horizontal */
 }
 
-/* Sección Fondo Principal */
-.fondo {
-    position: relative;
-    width: 100%; /* Asegura que ocupe todo el ancho de la pantalla */
-    height: 100vh; /* Ocupa el alto completo de la ventana */
-    overflow: hidden; /* Evita el desbordamiento de la imagen */
+main {
+    margin-top: 160px; /* Espacio para la barra fija */
 }
 
-/* Imagen de Fondo */
-.fondo img {
-    position: absolute; /* Hace que la imagen se quede fija */
-    top: 0;
-    left: 0;
-    width: 100%; /* La imagen ocupará todo el ancho disponible */
-    height: 100%; /* Asegura que ocupe todo el alto disponible */
-    object-fit: cover; /* Asegura que la imagen se ajuste sin distorsionarse */
-    object-position: center; /* Centra la imagen */
+.imagen1 img {
+    display: block;
+    margin: 0 auto;
+    max-width: 100%;
+    height: auto;
 }
 
 /* Color negro para la parte "Proge" */
@@ -33,16 +25,6 @@ html, body {
 /* Color naranja para la parte "Sync" */
 .sync {
     color: #F28C28; /* Aquí va el código de color naranja que usas */
-}
-
-/* Barra Superior */
-.barra-superior {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 20px 50px; /* Espaciado a los lados */
-    background-color: #ffffff; /* Fondo blanco */
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Sombra suave */
 }
 
 /* Logo */
@@ -63,35 +45,48 @@ html, body {
     color: #003366; /* Cambio de color al pasar el ratón */
 }
 
-/* Menú de opciones */
-.menu h2 {
+.barra-superior {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    padding: 20px 50px; /* Espaciado a los lados */
+    background-color: #ffffff; /* Fondo blanco */
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* Sombra suave */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+}
+
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
     font-size: 2rem;
     cursor: pointer;
-    color: #000000;  /* Color del enlace */
-    margin-left: 20px;
 }
 
-.menu h2:hover {
-    text-decoration: underline; /* Subrayado al pasar el ratón */
-}
-
-.navegacion{
+.navegacion {
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: #003366; /* Fondo claro para la navegación */
+    background-color: #003366; /* Fondo azul para la navegación */
+    width: 100%;
     padding: 10px 20px;
 }
 
-.navegacion h2{
+.nav-link {
     font-size: 1.2rem;
     font-weight: bold;
     color: #ffffff;
     margin: 0 15px;
-    cursor: pointer;
+    text-decoration: none;
 }
 
-.navegacion h2:hover{
+.nav-link:hover,
+.nav-link:focus {
     text-decoration: underline;
     color: #f8f9fa;
 }
@@ -116,13 +111,15 @@ html, body {
     margin: 0 auto; /* Centrar el texto */
 }
 
+
 .caracteristicas {
     display:flex; /* Usamos Flexbox para distribuir las tarjetas */
     flex-wrap: wrap; /* Para que las tarjetas se acomoden en filas si es necesario */
     justify-content: center; /* Espaciado entre las tarjetas */
     gap: 5px; /* Espaciado entre las tarjetas */
     padding: 40px 20px;
-    background-color: #ffffff;
+    background: rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(5px);
     text-align: center;
 }
 
@@ -163,7 +160,8 @@ html, body {
 
 .quienes_somos {
     padding: 50px 20px;
-    background-color: #f8f9fa;
+    background: rgba(255, 255, 255, 0.7);
+    backdrop-filter: blur(5px);
     text-align: center;
 }
 
@@ -230,6 +228,24 @@ html, body {
     align-items: center;
 }
 
+.contact-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.copy-btn {
+    background: none;
+    border: none;
+    color: #ffffff;
+    cursor: pointer;
+}
+
+.copy-btn:hover,
+.copy-btn:focus {
+    color: #ffcc00;
+}
+
 .footer-i {
     margin-right: 10px;
     color:#ffcc00;
@@ -251,7 +267,36 @@ html, body {
     }
 }
 
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}
+
 @media (max-width: 768px) {
+    .menu-toggle {
+        display: block;
+        color: #003366;
+    }
+
+    .navegacion {
+        display: none;
+        flex-direction: column;
+        align-items: flex-start;
+        width: 100%;
+    }
+
+    .navegacion.open {
+        animation: fadeIn 0.3s ease-in-out;
+    }
+
+    .navegacion.closing {
+        animation: fadeOut 0.3s ease-in-out forwards;
+    }
+
     .caracteristicas {
         flex-direction: column; /* Las tarjetas se apilan verticalmente en pantallas pequeñas */
         align-items: center; /* Centra las tarjetas */

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,31 +17,21 @@
             <span class="proge">Proge</span><span class="sync">Sync</span>
         </h1>
 
-        <div class="menu fade-in">
-            <h2 class="opcion1 fade-in" onclick="location.href='iniciosesion/iniciosesion.html'">Iniciar Sesión</h2>
-        </div>    
-        </header>
+        <button class="menu-toggle" aria-label="Abrir menú">
+            <i class="fas fa-bars"></i>
+        </button>
 
-    <nav class="navegacion fade-in">
-        <h2 class="navegacion1 fade-in" onclick="location.href='index.html'">Inicio</h2>
-
-        <!-- Entregas: corregida la ruta para que apunte a Estudiante -->
-        <h2
-            id="link-entregas"
-            class="navegacion2 fade-in"
-            role="button"
-            tabindex="0"
-            onclick="location.href='Entregas/Estudiante/entregas.html'">
-            Entregas
-        </h2>
-
-        <h2 class="navegacion3 fade-in" onclick="location.href='Seguimiento/seguimiento.html'">Seguimiento</h2>
-        <h2 class="navegacion3 fade-in" onclick="location.href='Notificacion/notificaciones.html'">Notificaciones</h2>
-        <h2 class="navegacion3 fade-in" onclick="location.href='Ayuda/ayuda.html'">Ayuda</h2>
-    </nav>
+        <nav class="navegacion fade-in">
+            <a class="nav-link" href="index.html">Inicio</a>
+            <a class="nav-link" href="Entregas/Estudiante/entregas.html">Entregas</a>
+            <a class="nav-link" href="Seguimiento/seguimiento.html">Seguimiento</a>
+            <a class="nav-link" href="Notificacion/notificaciones.html">Notificaciones</a>
+            <a class="nav-link" href="Ayuda/ayuda.html">Ayuda</a>
+            <a class="nav-link" href="iniciosesion/iniciosesion.html">Iniciar Sesión</a>
+        </nav>
+    </header>
 
     <main>
-        <!--<div class="fondo fade-in"> cambiarlo-->
         <div class="imagen1 fade-in">
             <img src="Imagenes/Fondomain.png" alt="Fondo Principal">
         </div>
@@ -97,26 +87,13 @@
 
         <div class="footer-contacto fade-in">
             <h3><i class="fas fa-mobile-alt"></i> Contáctanos</h3>
-            <p><i class="fas fa-phone"></i> 3208673417</p>
-            <p><i class="fas fa-phone"></i> 3112414027</p>
-            <p><i class="fas fa-phone"></i> 3167117358</p>
+            <p class="contact-item"><span>3208673417</span><button class="copy-btn" data-copy="3208673417"><i class="fas fa-copy"></i></button></p>
+            <p class="contact-item"><span>3112414027</span><button class="copy-btn" data-copy="3112414027"><i class="fas fa-copy"></i></button></p>
+            <p class="contact-item"><span>3167117358</span><button class="copy-btn" data-copy="3167117358"><i class="fas fa-copy"></i></button></p>
+            <p class="contact-item"><span>contacto.progresync@gmail.com</span><button class="copy-btn" data-copy="contacto.progresync@gmail.com"><i class="fas fa-copy"></i></button></p>
         </div>
     </footer>
 
-    <!-- JS mínimo para accesibilidad del enlace de Entregas sin tocar el resto -->
-    <script>
-      (function () {
-        const link = document.getElementById('link-entregas');
-        if (!link) return;
-
-        link.addEventListener('keydown', (ev) => {
-          // Permite activar con Enter o Space
-          if (ev.key === 'Enter' || ev.key === ' ') {
-            ev.preventDefault();
-            window.location.href = 'Entregas/Estudiante/entregas.html';
-          }
-        });
-      })();
-    </script>
+    <script src="index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.querySelector('.menu-toggle');
+  const nav = document.querySelector('.navegacion');
+
+  if (toggle && nav) {
+    toggle.addEventListener('click', () => {
+      if (nav.classList.contains('open')) {
+        nav.classList.remove('open');
+        nav.classList.add('closing');
+        nav.addEventListener('animationend', function handler() {
+          nav.classList.remove('closing');
+          nav.style.display = 'none';
+          nav.removeEventListener('animationend', handler);
+        });
+      } else {
+        nav.style.display = 'flex';
+        nav.classList.add('open');
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth > 768) {
+        nav.style.display = '';
+        nav.classList.remove('open', 'closing');
+      }
+    });
+  }
+
+  document.querySelectorAll('.copy-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const text = btn.getAttribute('data-copy');
+      if (text) {
+        navigator.clipboard.writeText(text);
+      }
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Simplified main banner by centering `Fondomain.png` and removing the stretched background
- Rebuilt top navigation with fixed positioning, hamburger menu on small screens and login link included
- Added copy buttons for phone numbers and new contact email in the footer

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd backend && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b879c093b483289979fcf9866e872f